### PR TITLE
Enables -Jred in default optimization for llvm-test-suite

### DIFF
--- a/llvm-test-suite/cmake/opt.cmake
+++ b/llvm-test-suite/cmake/opt.cmake
@@ -1,6 +1,6 @@
 # O3 = --iln --inv --red --dne --ivt --inv --dne --psh --inv --dne
 #      --red --cne --dne --pll --inv --dne --url --inv
-set(OPTFLAGS "${OPTFLAGS} -JInvariantValueRedirection -Jdne -Jivt -JInvariantValueRedirection -Jdne -JInvariantValueRedirection -Jdne -Jcne -Jdne -Jpll -JInvariantValueRedirection -Jdne -Jurl -JInvariantValueRedirection")
+set(OPTFLAGS "${OPTFLAGS} -JInvariantValueRedirection -JNodeReduction -Jdne -Jivt -JInvariantValueRedirection -Jdne -JInvariantValueRedirection -Jdne -JNodeReduction -Jcne -Jdne -Jpll -JInvariantValueRedirection -Jdne -Jurl -JInvariantValueRedirection")
 
 set(CMAKE_C_FLAGS_RELEASE "${OPTFLAGS}" CACHE STRING "")
 set(CMAKE_CXX_FLAGS_RELEASE "${OPTFLAGS}" CACHE STRING "")


### PR DESCRIPTION
Was previously part of the parallel compilation of the llvm-test-suite but made it into its on PR.