### PR TITLE
Add andersen version of llvm test suite, with a few tests filtered out

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,12 +56,27 @@ jobs:
         key: ${{ runner.os }}-${{ github.sha }}-jlm
     - name: "Install LLVM, Clang, MLIR, and Ninja"
       uses: ./.github/actions/InstallLlvmDependencies
-    - name: "Update llvm-test-suite submodule"
-      run: git submodule update --init llvm-test-suite/llvm-test-suite.git
-    - name: "Apply patch"
+    - name: "Update llvm-test-suite submodule and apply patch"
       run: make apply-llvm-git-patch
     - name: "Run llvm-test-suite"
       run: make llvm-run-opt
+
+  llvm-test-suite-andersen:
+    runs-on: ubuntu-22.04
+    needs: build-jlm
+    steps:
+    - uses: actions/checkout@v4
+    - name: "Cache"
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/jlm/*
+        key: ${{ runner.os }}-${{ github.sha }}-jlm
+    - name: "Install LLVM, Clang, MLIR, and Ninja"
+      uses: ./.github/actions/InstallLlvmDependencies
+    - name: "Update llvm-test-suite submodule and apply patch"
+      run: make apply-llvm-git-patch
+    - name: "Run llvm-test-suite"
+      run: make llvm-run-andersen
 
   hls-test-suite:
     runs-on: ubuntu-22.04

--- a/llvm-test-suite/Makefile.sub
+++ b/llvm-test-suite/Makefile.sub
@@ -23,6 +23,7 @@ install-lit:
 
 .PHONY: apply-llvm-git-patch
 apply-llvm-git-patch:
+	git submodule update --init --recursive --force $(LLVM_TEST_GIT)
 	cd $(LLVM_TEST_GIT) && git apply $(LLVM_TEST_ROOT)/jlc.patch
 
 # Use cmake with -LAH to see all configuration options
@@ -51,6 +52,13 @@ llvm-build-aa:
 		$(CMAKE_CONFIG) \
 		-C$(LLVM_TEST_ROOT)/cmake/aa.cmake $(LLVM_TEST_GIT)
 	cd $(LLVM_TEST_BUILD)-aa && make -j `nproc` VERBOSE=1 SHELL="/bin/bash -x"
+
+.PHONY: llvm-build-andersen
+llvm-build-andersen:
+	cmake $(CMAKE_CONFIG) \
+		-B$(LLVM_TEST_BUILD)-andersen \
+		-C$(LLVM_TEST_ROOT)/cmake/Andersen.cmake $(LLVM_TEST_GIT)
+	cd $(LLVM_TEST_BUILD)-andersen && make -j `nproc` VERBOSE=1 SHELL="/bin/bash -x"
 
 .PHONY: llvm-build-cne
 llvm-build-cne:
@@ -141,6 +149,12 @@ llvm-run-aa: llvm-build-aa
 	cd $(LLVM_TEST_BUILD)-aa && lit -v -j `nproc` -o results.json .
 
 # No failed tests
+
+# Make sure you apply the andersen
+.PHONY: llvm-run-andersen
+llvm-run-andersen: llvm-build-andersen
+	cd $(LLVM_TEST_BUILD)-andersen && lit -v -j `nproc` -o results.json .
+
 
 .PHONY: llvm-run-cne
 llvm-run-cne: llvm-build-cne

--- a/llvm-test-suite/cmake/Andersen.cmake
+++ b/llvm-test-suite/cmake/Andersen.cmake
@@ -1,0 +1,7 @@
+set(OPTFLAGS "${OPTFLAGS} -JAAAndersenAgnostic")
+# set(OPTFLAGS "${OPTFLAGS} -JInvariantValueRedirection -JNodeReduction -JDeadNodeElimination -JThetaGammaInversion -JInvariantValueRedirection -JDeadNodeElimination -JInvariantValueRedirection -JDeadNodeElimination -JNodeReduction -JCommonNodeElimination -JDeadNodeElimination -JNodePullIn -JInvariantValueRedirection -JDeadNodeElimination -JLoopUnrolling -JInvariantValueRedirection")
+
+set(JLC_WITH_ANDERSEN "YES" CACHE STRING "Disable tests that do not work with Andersen")
+set(CMAKE_C_FLAGS_RELEASE "${OPTFLAGS}" CACHE STRING "")
+set(CMAKE_CXX_FLAGS_RELEASE "${OPTFLAGS}" CACHE STRING "")
+set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")

--- a/llvm-test-suite/jlc.patch
+++ b/llvm-test-suite/jlc.patch
@@ -26,10 +26,20 @@ index 08d3dd44..7170c2f3 100644
 +#add_subdirectory(MemFunctions)
 +#add_subdirectory(SLPVectorization)
 diff --git a/MultiSource/Applications/CMakeLists.txt b/MultiSource/Applications/CMakeLists.txt
-index b008394f..8c6bce37 100644
+index b008394f..be7b37e4 100644
 --- a/MultiSource/Applications/CMakeLists.txt
 +++ b/MultiSource/Applications/CMakeLists.txt
-@@ -14,21 +14,28 @@ add_subdirectory(sgefa)
+@@ -8,30 +8,43 @@ add_subdirectory(d)
+ if(NOT ARCH STREQUAL "PowerPC")
+ # This test has problems running on powerpc starting with r295538 and should
+ # be restored when the issue is corrected.
+-  add_subdirectory(oggenc)
++  if(NOT DEFINED JLC_WITH_ANDERSEN)
++    # JLC: Andersen runs out of memory
++    add_subdirectory(oggenc)
++  endif()
+ endif()
+ add_subdirectory(sgefa)
  add_subdirectory(spiff)
  add_subdirectory(viterbi)
  
@@ -64,7 +74,26 @@ index b008394f..8c6bce37 100644
 +#  add_subdirectory(kimwitu++)
  endif()
  if(NOT TARGET_OS STREQUAL "SunOS")
-   add_subdirectory(SPASS)
+-  add_subdirectory(SPASS)
++  if(NOT DEFINED JLC_WITH_ANDERSEN)
++    # JLC: Andersen runs out of memory
++    add_subdirectory(SPASS)
++  endif()
+ endif()
+ if(NOT ARCH STREQUAL "XCore")
+   add_subdirectory(ClamAV)
+@@ -39,7 +52,10 @@ if(NOT ARCH STREQUAL "XCore")
+   add_subdirectory(siod)
+ endif()
+ if((NOT ARCH STREQUAL "PowerPC") AND (NOT ARCH STREQUAL "XCore"))
+-  add_subdirectory(sqlite3)
++  if(NOT DEFINED JLC_WITH_ANDERSEN)
++    # JLC: Andersen runs out of memory
++    add_subdirectory(sqlite3)
++  endif()
+ endif()
+ if(NOT TEST_SUITE_BENCHMARKING_ONLY)
+   add_subdirectory(Burg)
 diff --git a/MultiSource/Applications/ClamAV/CMakeLists.txt b/MultiSource/Applications/ClamAV/CMakeLists.txt
 index f08da4c0..8b28b30d 100644
 --- a/MultiSource/Applications/ClamAV/CMakeLists.txt


### PR DESCRIPTION
Instead of creating a separate `jlc.patch`, it adds some conditionals to the cmake files, to skip tests when `JLM_WITH_ANDERSEN` is defined, which only happens in `llvm-eval-suite/cmake/Andersen.cmake`.

The conditionally skipped tests are:

 - MultiSource/Applications/sqlite3
 - MultiSource/Applications/SPASS

due to running out of memory. This PR also serves as a test to see if `make -j $(nproc)` even works on the GitHub Actions runner, as it has 4 cores, and 16 GB of RAM. (Or 2 cores 7 GB RAM on private runners)