### PR TITLE
Add make targets and CI job for SteensgaardAgnostic pass

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,6 +78,23 @@ jobs:
     - name: "Run llvm-test-suite"
       run: make llvm-run-andersen
 
+  llvm-test-suite-steensgaard-agnostic:
+    runs-on: ubuntu-22.04
+    needs: build-jlm
+    steps:
+    - uses: actions/checkout@v4
+    - name: "Cache"
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/jlm/*
+        key: ${{ runner.os }}-${{ github.sha }}-jlm
+    - name: "Install LLVM, Clang, MLIR, and Ninja"
+      uses: ./.github/actions/InstallLlvmDependencies
+    - name: "Update llvm-test-suite submodule and apply patch"
+      run: make apply-llvm-git-patch
+    - name: "Run LLVM test suite"
+      run: make llvm-run-steensgaard-agnostic
+
   hls-test-suite:
     runs-on: ubuntu-22.04
     needs: build-jlm

--- a/llvm-test-suite/Makefile.sub
+++ b/llvm-test-suite/Makefile.sub
@@ -60,6 +60,13 @@ llvm-build-andersen:
 		-C$(LLVM_TEST_ROOT)/cmake/Andersen.cmake $(LLVM_TEST_GIT)
 	cd $(LLVM_TEST_BUILD)-andersen && make -j `nproc` VERBOSE=1 SHELL="/bin/bash -x"
 
+.PHONY: llvm-build-steensgaard-agnostic
+llvm-build-steensgaard-agnostic:
+	cmake $(CMAKE_CONFIG) \
+		-B $(LLVM_TEST_BUILD)-steensgaard-agnostic \
+		-C $(LLVM_TEST_ROOT)/cmake/SteensgaardAgnostic.cmake $(LLVM_TEST_GIT)
+	cd $(LLVM_TEST_BUILD)-steensgaard-agnostic && make -j `nproc` VERBOSE=1 SHELL="/bin/bash -x"
+
 .PHONY: llvm-build-cne
 llvm-build-cne:
 	mkdir -p $(LLVM_TEST_BUILD)-cne
@@ -154,6 +161,10 @@ llvm-run-aa: llvm-build-aa
 .PHONY: llvm-run-andersen
 llvm-run-andersen: llvm-build-andersen
 	cd $(LLVM_TEST_BUILD)-andersen && lit -v -j `nproc` -o results.json .
+
+.PHONY: llvm-run-steensgaard-agnostic
+llvm-run-steensgaard-agnostic: llvm-build-steensgaard-agnostic
+	cd $(LLVM_TEST_BUILD)-steensgaard-agnostic && lit -v -j `nproc` -o results.json .
 
 
 .PHONY: llvm-run-cne

--- a/llvm-test-suite/cmake/SteensgaardAgnostic.cmake
+++ b/llvm-test-suite/cmake/SteensgaardAgnostic.cmake
@@ -1,0 +1,7 @@
+set(OPTFLAGS "${OPTFLAGS} -JAASteensgaardAgnostic")
+
+set(STEENSGAARD_AGNOSTIC_ENABLED "YES" CACHE STRING "Determines whether Steensgaard alias analysis with agnostic encoding is enabled.")
+set(CMAKE_C_FLAGS_RELEASE "${OPTFLAGS}" CACHE STRING "")
+set(CMAKE_CXX_FLAGS_RELEASE "${OPTFLAGS}" CACHE STRING "")
+set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
+

--- a/llvm-test-suite/jlc.patch
+++ b/llvm-test-suite/jlc.patch
@@ -26,16 +26,17 @@ index 08d3dd44..7170c2f3 100644
 +#add_subdirectory(MemFunctions)
 +#add_subdirectory(SLPVectorization)
 diff --git a/MultiSource/Applications/CMakeLists.txt b/MultiSource/Applications/CMakeLists.txt
-index b008394f..be7b37e4 100644
+index b008394f..189a1ba5 100644
 --- a/MultiSource/Applications/CMakeLists.txt
 +++ b/MultiSource/Applications/CMakeLists.txt
-@@ -8,30 +8,43 @@ add_subdirectory(d)
+@@ -8,30 +8,44 @@ add_subdirectory(d)
  if(NOT ARCH STREQUAL "PowerPC")
  # This test has problems running on powerpc starting with r295538 and should
  # be restored when the issue is corrected.
 -  add_subdirectory(oggenc)
-+  if(NOT DEFINED JLC_WITH_ANDERSEN)
++  if((NOT DEFINED JLC_WITH_ANDERSEN) AND (NOT DEFINED STEENSGAARD_AGNOSTIC_ENABLED))
 +    # JLC: Andersen runs out of memory
++    # JLC: Steensgaard with agnostic encoding runs out of memory
 +    add_subdirectory(oggenc)
 +  endif()
  endif()
@@ -82,13 +83,14 @@ index b008394f..be7b37e4 100644
  endif()
  if(NOT ARCH STREQUAL "XCore")
    add_subdirectory(ClamAV)
-@@ -39,7 +52,10 @@ if(NOT ARCH STREQUAL "XCore")
+@@ -39,7 +53,11 @@ if(NOT ARCH STREQUAL "XCore")
    add_subdirectory(siod)
  endif()
  if((NOT ARCH STREQUAL "PowerPC") AND (NOT ARCH STREQUAL "XCore"))
 -  add_subdirectory(sqlite3)
-+  if(NOT DEFINED JLC_WITH_ANDERSEN)
++  if((NOT DEFINED JLC_WITH_ANDERSEN) AND (NOT DEFINED STEENSGAARD_AGNOSTIC_ENABLED))
 +    # JLC: Andersen runs out of memory
++    # JLC: Steensgaard with agnostic encoding runs out of memory
 +    add_subdirectory(sqlite3)
 +  endif()
  endif()
@@ -116,10 +118,24 @@ index 2a0be7f2..e89d379c 100644
 +# JLC produces the wrong result
 +#add_subdirectory(lencod)
 diff --git a/MultiSource/Benchmarks/CMakeLists.txt b/MultiSource/Benchmarks/CMakeLists.txt
-index 61d1fd08..5911b1ac 100644
+index 61d1fd08..43b06c81 100644
 --- a/MultiSource/Benchmarks/CMakeLists.txt
 +++ b/MultiSource/Benchmarks/CMakeLists.txt
-@@ -22,17 +22,19 @@ add_subdirectory(Rodinia)
+@@ -4,7 +4,12 @@ add_subdirectory(BitBench)
+ add_subdirectory(Fhourstones)
+ add_subdirectory(Fhourstones-3.1)
+ add_subdirectory(FreeBench)
+-add_subdirectory(MallocBench)
++
++if(NOT DEFINED STEENSGAARD_AGNOSTIC_ENABLED)
++  # JLC: Steensgaard with agnotic encoding leads to test failure
++  add_subdirectory(MallocBench)
++endif()
++
+ add_subdirectory(McCat)
+ add_subdirectory(NPB-serial)
+ add_subdirectory(Olden)
+@@ -22,17 +27,19 @@ add_subdirectory(Rodinia)
  if((NOT "${TARGET_OS}" STREQUAL "Darwin") OR (NOT "${ARCH}" STREQUAL "ARM"))
    add_subdirectory(TSVC)
  endif()


### PR DESCRIPTION
This PR does the following:

1. Add make target for compiling LLVM test suite with jlc and optimization SteensgaardAgnostic
2. Add CI job to running this target

I had to exclude the following benchmarks for this target:
1. oggenc: Jlc ran out of memory.
3. sqlite3: jlc ran out of memory.
4. MallocBench: jlc produced the wrong result.

I will eventually attend to these problems, but would rather move on for now with a "functioning" baseline for SteensgaardAgnostic and build on top of it.