### PR TITLE
Rename Andersen targets to AndersenAgnostic

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,7 +61,7 @@ jobs:
     - name: "Run llvm-test-suite"
       run: make llvm-run-opt
 
-  llvm-test-suite-andersen:
+  llvm-test-suite-andersen-agnostic:
     runs-on: ubuntu-22.04
     needs: build-jlm
     steps:
@@ -76,7 +76,7 @@ jobs:
     - name: "Update llvm-test-suite submodule and apply patch"
       run: make apply-llvm-git-patch
     - name: "Run llvm-test-suite"
-      run: make llvm-run-andersen
+      run: make llvm-run-andersen-agnostic
 
   llvm-test-suite-steensgaard-agnostic:
     runs-on: ubuntu-22.04

--- a/llvm-test-suite/Makefile.sub
+++ b/llvm-test-suite/Makefile.sub
@@ -53,12 +53,12 @@ llvm-build-aa:
 		-C$(LLVM_TEST_ROOT)/cmake/aa.cmake $(LLVM_TEST_GIT)
 	cd $(LLVM_TEST_BUILD)-aa && make -j `nproc` VERBOSE=1 SHELL="/bin/bash -x"
 
-.PHONY: llvm-build-andersen
-llvm-build-andersen:
+.PHONY: llvm-build-andersen-agnostic
+llvm-build-andersen-agnostic:
 	cmake $(CMAKE_CONFIG) \
-		-B$(LLVM_TEST_BUILD)-andersen \
-		-C$(LLVM_TEST_ROOT)/cmake/Andersen.cmake $(LLVM_TEST_GIT)
-	cd $(LLVM_TEST_BUILD)-andersen && make -j `nproc` VERBOSE=1 SHELL="/bin/bash -x"
+		-B$(LLVM_TEST_BUILD)-andersen-agnostic \
+		-C$(LLVM_TEST_ROOT)/cmake/AndersenAgnostic.cmake $(LLVM_TEST_GIT)
+	cd $(LLVM_TEST_BUILD)-andersen-agnostic && make -j `nproc` VERBOSE=1 SHELL="/bin/bash -x"
 
 .PHONY: llvm-build-steensgaard-agnostic
 llvm-build-steensgaard-agnostic:
@@ -158,9 +158,9 @@ llvm-run-aa: llvm-build-aa
 # No failed tests
 
 # Make sure you apply the andersen
-.PHONY: llvm-run-andersen
-llvm-run-andersen: llvm-build-andersen
-	cd $(LLVM_TEST_BUILD)-andersen && lit -v -j `nproc` -o results.json .
+.PHONY: llvm-run-andersen-agnostic
+llvm-run-andersen-agnostic: llvm-build-andersen-agnostic
+	cd $(LLVM_TEST_BUILD)-andersen-agnostic && lit -v -j `nproc` -o results.json .
 
 .PHONY: llvm-run-steensgaard-agnostic
 llvm-run-steensgaard-agnostic: llvm-build-steensgaard-agnostic

--- a/llvm-test-suite/cmake/AndersenAgnostic.cmake
+++ b/llvm-test-suite/cmake/AndersenAgnostic.cmake
@@ -1,7 +1,7 @@
 set(OPTFLAGS "${OPTFLAGS} -JAAAndersenAgnostic")
 # set(OPTFLAGS "${OPTFLAGS} -JInvariantValueRedirection -JNodeReduction -JDeadNodeElimination -JThetaGammaInversion -JInvariantValueRedirection -JDeadNodeElimination -JInvariantValueRedirection -JDeadNodeElimination -JNodeReduction -JCommonNodeElimination -JDeadNodeElimination -JNodePullIn -JInvariantValueRedirection -JDeadNodeElimination -JLoopUnrolling -JInvariantValueRedirection")
 
-set(JLC_WITH_ANDERSEN "YES" CACHE STRING "Disable tests that do not work with Andersen")
+set(JLC_WITH_ANDERSEN_AGNOSTIC "YES" CACHE STRING "Disable tests that do not work with AndersenAgnostic")
 set(CMAKE_C_FLAGS_RELEASE "${OPTFLAGS}" CACHE STRING "")
 set(CMAKE_CXX_FLAGS_RELEASE "${OPTFLAGS}" CACHE STRING "")
 set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")

--- a/llvm-test-suite/jlc.patch
+++ b/llvm-test-suite/jlc.patch
@@ -26,7 +26,7 @@ index 08d3dd44..7170c2f3 100644
 +#add_subdirectory(MemFunctions)
 +#add_subdirectory(SLPVectorization)
 diff --git a/MultiSource/Applications/CMakeLists.txt b/MultiSource/Applications/CMakeLists.txt
-index b008394f..189a1ba5 100644
+index b008394f..fb0cf2ff 100644
 --- a/MultiSource/Applications/CMakeLists.txt
 +++ b/MultiSource/Applications/CMakeLists.txt
 @@ -8,30 +8,44 @@ add_subdirectory(d)
@@ -34,8 +34,8 @@ index b008394f..189a1ba5 100644
  # This test has problems running on powerpc starting with r295538 and should
  # be restored when the issue is corrected.
 -  add_subdirectory(oggenc)
-+  if((NOT DEFINED JLC_WITH_ANDERSEN) AND (NOT DEFINED STEENSGAARD_AGNOSTIC_ENABLED))
-+    # JLC: Andersen runs out of memory
++  if((NOT DEFINED JLC_WITH_ANDERSEN_AGNOSTIC) AND (NOT DEFINED STEENSGAARD_AGNOSTIC_ENABLED))
++    # JLC: Andersen with agnostic encoding runs out of memory
 +    # JLC: Steensgaard with agnostic encoding runs out of memory
 +    add_subdirectory(oggenc)
 +  endif()
@@ -76,8 +76,8 @@ index b008394f..189a1ba5 100644
  endif()
  if(NOT TARGET_OS STREQUAL "SunOS")
 -  add_subdirectory(SPASS)
-+  if(NOT DEFINED JLC_WITH_ANDERSEN)
-+    # JLC: Andersen runs out of memory
++  if(NOT DEFINED JLC_WITH_ANDERSEN_AGNOSTIC)
++    # JLC: Andersen with agnostic encoding runs out of memory
 +    add_subdirectory(SPASS)
 +  endif()
  endif()
@@ -88,8 +88,8 @@ index b008394f..189a1ba5 100644
  endif()
  if((NOT ARCH STREQUAL "PowerPC") AND (NOT ARCH STREQUAL "XCore"))
 -  add_subdirectory(sqlite3)
-+  if((NOT DEFINED JLC_WITH_ANDERSEN) AND (NOT DEFINED STEENSGAARD_AGNOSTIC_ENABLED))
-+    # JLC: Andersen runs out of memory
++  if((NOT DEFINED JLC_WITH_ANDERSEN_AGNOSTIC) AND (NOT DEFINED STEENSGAARD_AGNOSTIC_ENABLED))
++    # JLC: Andersen with agnostic encoding runs out of memory
 +    # JLC: Steensgaard with agnostic encoding runs out of memory
 +    add_subdirectory(sqlite3)
 +  endif()


### PR DESCRIPTION
Renaming the targets for compiling Andersen with agnostic memory state encoding. I want to introduce targets for Andersen with region-aware memory state encoding, so we need to be more specific.